### PR TITLE
chore: リポジトリ名を web-native-monorepo-template に変更

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -7,7 +7,7 @@
 ### ディレクトリ構造
 
 ```
-nextjs-expo-monorepo-template/
+web-native-monorepo-template/
 ├── .claude/                    # Claude Code設定
 ├── .vscode/                    # VS Code設定
 ├── apps/

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "nextjs-expo-monorepo-template",
+  "name": "web-native-monorepo-template",
   "private": true,
   "scripts": {
     "build": "turbo run build",


### PR DESCRIPTION
## 概要
リポジトリ名を `nextjs-expo-monorepo-template` から `web-native-monorepo-template` に変更します。

## 変更理由
- **技術中立性**: 「web」はNext.jsに限定されず、他のWebフレームワークへの変更も示唆できる
- **対称性**: `web` と `native` でプラットフォームを明確に表現
- **一貫性**: プロジェクト内の `apps/web` と `apps/native` のディレクトリ名と整合性が取れる

## 変更内容
- `package.json` の name フィールドを更新
- `docs/DEVELOPMENT.md` のディレクトリ構造説明を更新

## 必要な作業
このPRマージ後、GitHub上でリポジトリ名を変更する必要があります：
1. Settings → General → Repository name を `web-native-monorepo-template` に変更
2. リポジトリURLが自動的にリダイレクトされます

## チェックリスト
- [x] コードがプロジェクトのスタイルガイドに従っている
- [x] 自己レビューを実施した
- [x] 破壊的変更がない

🤖 Generated with [Claude Code](https://claude.ai/code)