### PR TITLE
fix: Claude Codeのサブエージェント・コマンド読み込み問題修正

### DIFF
--- a/.claude/agents/document-fixer.md
+++ b/.claude/agents/document-fixer.md
@@ -1,13 +1,13 @@
-<!--
-Based on ai-coding-project-boilerplate by Shinsuke Kagawa
-https://github.com/shinpr/ai-coding-project-boilerplate
--->
-
 ---
 name: document-fixer
 description: 複数観点のレビューを統合し、ドキュメントを自動修正する専門エージェント。document-reviewerを異なるコンテキストで並列実行し、結果を統合して修正まで完全に実施します。
 tools: Read, Write, Edit, MultiEdit, Task, TodoWrite
 ---
+
+<!--
+Based on ai-coding-project-boilerplate by Shinsuke Kagawa
+https://github.com/shinpr/ai-coding-project-boilerplate
+-->
 
 あなたはドキュメントの多角的レビューを統合し、自動修正まで完全に実行する専門のAIアシスタントです。レビューのみの実行は行わず、必ず問題の修正まで実施します。
 

--- a/.claude/agents/document-reviewer.md
+++ b/.claude/agents/document-reviewer.md
@@ -1,13 +1,13 @@
-<!--
-Based on ai-coding-project-boilerplate by Shinsuke Kagawa
-https://github.com/shinpr/ai-coding-project-boilerplate
--->
-
 ---
 name: document-reviewer
 description: ドキュメントの整合性と完成度をレビューする専門エージェント。矛盾やルール違反を検出し、改善提案と承認判定を提供します。観点モードにより特定の視点に特化したレビューも可能です。
 tools: Read, Grep, Glob, LS, Task, TodoWrite
 ---
+
+<!--
+Based on ai-coding-project-boilerplate by Shinsuke Kagawa
+https://github.com/shinpr/ai-coding-project-boilerplate
+-->
 
 あなたは技術ドキュメントのレビューを専門とするAIアシスタントです。
 

--- a/.claude/agents/prd-creator.md
+++ b/.claude/agents/prd-creator.md
@@ -1,13 +1,13 @@
-<!--
-Based on ai-coding-project-boilerplate by Shinsuke Kagawa
-https://github.com/shinpr/ai-coding-project-boilerplate
--->
-
 ---
 name: prd-creator
 description: Product Requirements Document（PRD）を作成する専門エージェント。ビジネス要件を構造化し、ユーザー価値と成功指標を定義します。
 tools: Read, Write, Edit, MultiEdit, Glob, LS, Task, TodoWrite
 ---
+
+<!--
+Based on ai-coding-project-boilerplate by Shinsuke Kagawa
+https://github.com/shinpr/ai-coding-project-boilerplate
+-->
 
 あなたはProduct Requirements Document (PRD) を作成する専門のAIアシスタントです。
 

--- a/.claude/agents/quality-fixer.md
+++ b/.claude/agents/quality-fixer.md
@@ -1,13 +1,13 @@
-<!--
-Based on ai-coding-project-boilerplate by Shinsuke Kagawa
-https://github.com/shinpr/ai-coding-project-boilerplate
--->
-
 ---
 name: quality-fixer
 description: TypeScriptプロジェクトの品質問題を修正する専門エージェント。コード品質、型安全性、テスト、ビルドに関するあらゆる検証と修正を完全自己完結で実行。全ての品質エラーを修正し、全テストがパスするまで責任をもって対応。MUST BE USED PROACTIVELY when any quality-related keywords appear (品質/quality/チェック/check/検証/verify/テスト/test/ビルド/build/lint/format/型/type/修正/fix) or after code changes. Handles all verification and fixing tasks autonomously.
 tools: Bash, Read, Edit, MultiEdit, Task, TodoWrite
 ---
+
+<!--
+Based on ai-coding-project-boilerplate by Shinsuke Kagawa
+https://github.com/shinpr/ai-coding-project-boilerplate
+-->
 
 あなたはTypeScriptプロジェクトの品質保証専門のAIアシスタントです。
 

--- a/.claude/agents/requirement-analyzer.md
+++ b/.claude/agents/requirement-analyzer.md
@@ -1,13 +1,13 @@
-<!--
-Based on ai-coding-project-boilerplate by Shinsuke Kagawa
-https://github.com/shinpr/ai-coding-project-boilerplate
--->
-
 ---
 name: requirement-analyzer
 description: 要件分析と作業規模判定を行う専門エージェント。ユーザー要求の本質を抽出し、適切な開発アプローチを提案します。
 tools: Read, Glob, LS, Task, TodoWrite
 ---
+
+<!--
+Based on ai-coding-project-boilerplate by Shinsuke Kagawa
+https://github.com/shinpr/ai-coding-project-boilerplate
+-->
 
 あなたは要件分析と作業規模判定を行う専門のAIアシスタントです。
 

--- a/.claude/agents/rule-advisor.md
+++ b/.claude/agents/rule-advisor.md
@@ -1,13 +1,13 @@
-<!--
-Based on ai-coding-project-boilerplate by Shinsuke Kagawa
-https://github.com/shinpr/ai-coding-project-boilerplate
--->
-
 ---
 name: rule-advisor
 description: AIの実行精度を最大化する観点で必要十分かつ最小限の効果的なルールセットを選択する専門エージェント。最大500行を目安に精度最大化を優先し、網羅的かつコンパクトで解釈しやすい結果を返す。MUST BE USED PROACTIVELY when starting any task through TodoWrite
 tools: Read, Grep, LS
 ---
+
+<!--
+Based on ai-coding-project-boilerplate by Shinsuke Kagawa
+https://github.com/shinpr/ai-coding-project-boilerplate
+-->
 
 あなたはルール選択専門のAIアシスタントです。タスクの性質を分析し、AIの実行精度を最大化する観点で必要十分かつ最小限の効果的なルールセットを動的に選択します。
 

--- a/.claude/agents/task-decomposer.md
+++ b/.claude/agents/task-decomposer.md
@@ -1,13 +1,13 @@
-<!--
-Based on ai-coding-project-boilerplate by Shinsuke Kagawa
-https://github.com/shinpr/ai-coding-project-boilerplate
--->
-
 ---
 name: task-decomposer
 description: docs/plansの作業計画書を読み込み、1コミット粒度の独立したタスクに分解してdocs/plans/tasksに配置する。PROACTIVELY 作業計画書が作成されたらタスク分解を提案。
 tools: Read, Write, LS, Bash, Task, TodoWrite
 ---
+
+<!--
+Based on ai-coding-project-boilerplate by Shinsuke Kagawa
+https://github.com/shinpr/ai-coding-project-boilerplate
+-->
 
 あなたは作業計画書を実行可能なタスクに分解する専門のAIアシスタントです。
 

--- a/.claude/agents/task-executor.md
+++ b/.claude/agents/task-executor.md
@@ -1,13 +1,13 @@
-<!--
-Based on ai-coding-project-boilerplate by Shinsuke Kagawa
-https://github.com/shinpr/ai-coding-project-boilerplate
--->
-
 ---
 name: task-executor
 description: 個別タスクを着実に実行する専門エージェント。タスクファイルの手順に従って実装し、進捗をリアルタイムで更新します。完全自己完結型で質問せず、調査から実装まで一貫して実行。
 tools: Read, Edit, Write, MultiEdit, Bash, Task, Grep, Glob, LS, TodoWrite
 ---
+
+<!--
+Based on ai-coding-project-boilerplate by Shinsuke Kagawa
+https://github.com/shinpr/ai-coding-project-boilerplate
+-->
 
 あなたは個別タスクを確実に実行する専門のAIアシスタントです。
 

--- a/.claude/agents/technical-designer.md
+++ b/.claude/agents/technical-designer.md
@@ -1,13 +1,13 @@
-<!--
-Based on ai-coding-project-boilerplate by Shinsuke Kagawa
-https://github.com/shinpr/ai-coding-project-boilerplate
--->
-
 ---
 name: technical-designer
 description: 技術設計ドキュメントを作成する専門エージェント。ADRとDesign Docを通じて、技術的選択肢の評価と実装アプローチを定義します。
 tools: Read, Write, Edit, MultiEdit, Glob, LS, Task, TodoWrite
 ---
+
+<!--
+Based on ai-coding-project-boilerplate by Shinsuke Kagawa
+https://github.com/shinpr/ai-coding-project-boilerplate
+-->
 
 あなたはArchitecture Decision Record (ADR) と Design Document を作成する技術設計専門のAIアシスタントです。
 

--- a/.claude/agents/work-planner.md
+++ b/.claude/agents/work-planner.md
@@ -1,13 +1,13 @@
-<!--
-Based on ai-coding-project-boilerplate by Shinsuke Kagawa
-https://github.com/shinpr/ai-coding-project-boilerplate
--->
-
 ---
 name: work-planner
 description: 作業計画書を作成する専門エージェント。設計ドキュメントを基に実装タスクを構造化し、進捗追跡可能な実行計画を立案します。
 tools: Read, Write, Edit, MultiEdit, Glob, LS, Task, TodoWrite
 ---
+
+<!--
+Based on ai-coding-project-boilerplate by Shinsuke Kagawa
+https://github.com/shinpr/ai-coding-project-boilerplate
+-->
 
 あなたは作業計画書を作成する専門のAIアシスタントです。
 

--- a/.claude/commands/build.md
+++ b/.claude/commands/build.md
@@ -1,11 +1,11 @@
+---
+description: 分解済みタスクを自律実行モードで実装
+---
+
 <!--
 Based on ai-coding-project-boilerplate by Shinsuke Kagawa
 https://github.com/shinpr/ai-coding-project-boilerplate
 -->
-
----
-description: 分解済みタスクを自律実行モードで実装
----
 
 **コマンドコンテキスト**: このコマンドは実装フェーズ専用です。
 

--- a/.claude/commands/design.md
+++ b/.claude/commands/design.md
@@ -1,11 +1,11 @@
+---
+description: 要件分析から設計書作成まで実行
+---
+
 <!--
 Based on ai-coding-project-boilerplate by Shinsuke Kagawa
 https://github.com/shinpr/ai-coding-project-boilerplate
 -->
-
----
-description: 要件分析から設計書作成まで実行
----
 
 **コマンドコンテキスト**: このコマンドは設計フェーズ専用です。
 

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -1,11 +1,11 @@
+---
+description: オーケストレーターとして要件分析から実装まで完全サイクルを管理
+---
+
 <!--
 Based on ai-coding-project-boilerplate by Shinsuke Kagawa
 https://github.com/shinpr/ai-coding-project-boilerplate
 -->
-
----
-description: オーケストレーターとして要件分析から実装まで完全サイクルを管理
----
 
 @docs/guides/sub-agents.md に基づき、オーケストレーターとして振る舞います。
 

--- a/.claude/commands/onboard.md
+++ b/.claude/commands/onboard.md
@@ -1,11 +1,11 @@
+---
+description: プロジェクトルールを読み込み、開発規約を徹底する
+---
+
 <!--
 Based on ai-coding-project-boilerplate by Shinsuke Kagawa
 https://github.com/shinpr/ai-coding-project-boilerplate
 -->
-
----
-description: プロジェクトルールを読み込み、開発規約を徹底する
----
 
 @CLAUDE.md と @docs/rules/ 配下の全ルールファイルを読み込んでください。
 

--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -1,11 +1,11 @@
+---
+description: 設計書から作業計画書を作成し計画承認を取得
+---
+
 <!--
 Based on ai-coding-project-boilerplate by Shinsuke Kagawa
 https://github.com/shinpr/ai-coding-project-boilerplate
 -->
-
----
-description: 設計書から作業計画書を作成し計画承認を取得
----
 
 **コマンドコンテキスト**: このコマンドは計画フェーズ専用です。
 

--- a/.claude/commands/rule-maintenance.md
+++ b/.claude/commands/rule-maintenance.md
@@ -1,11 +1,11 @@
+---
+description: ルールファイル群の用語統一と整合性維持を実行
+---
+
 <!--
 Based on ai-coding-project-boilerplate by Shinsuke Kagawa
 https://github.com/shinpr/ai-coding-project-boilerplate
 -->
-
----
-description: ルールファイル群の用語統一と整合性維持を実行
----
 
 # ルールファイル整合性維持コマンド
 

--- a/.claude/commands/task.md
+++ b/.claude/commands/task.md
@@ -1,11 +1,11 @@
+---
+description: タスクを適切なルールに従って実行
+---
+
 <!--
 Based on ai-coding-project-boilerplate by Shinsuke Kagawa
 https://github.com/shinpr/ai-coding-project-boilerplate
 -->
-
----
-description: タスクを適切なルールに従って実行
----
 
 タスク: $ARGUMENTS
 


### PR DESCRIPTION
## 概要
Claude Codeのサブエージェントとコマンドが正常に読み込まれない問題を修正

## 背景
- サブエージェント（document-reviewerなど）が利用できない状態
- `.claude/agents/`と`.claude/commands/`のファイルでコメントブロックがfrontmatterの前に配置
- Claude Codeはfrontmatterが先頭にある形式を期待

## 変更内容
### サブエージェントファイル修正
- document-reviewer.md
- prd-creator.md
- quality-fixer.md
- task-decomposer.md
- technical-designer.md
- work-planner.md
- rule-advisor.md
- requirement-analyzer.md
- task-executor.md

### コマンドファイル修正
- rule-maintenance.md
- implement.md
- onboard.md
- build.md
- task.md
- plan.md
- design.md

すべてのファイルでコメントブロック（`<\!--...-->`）をfrontmatter（`---...---`）の後に移動。

## 影響範囲
- [x] Claude Codeメタデータ
- [ ] Web アプリ
- [ ] Native アプリ
- [ ] 共有UIコンポーネント
- [ ] TypeScript設定

## 変更の種類
- [ ] 新機能
- [x] バグ修正
- [ ] ドキュメント更新
- [ ] リファクタリング
- [ ] テスト追加
- [ ] 設定変更

## 技術的チェックリスト
- [x] pnpm fix 実行済み
- [x] pnpm check-types 実行済み
- [x] pnpm check 実行済み
- [x] 適切なコミットメッセージ
- [x] 変更内容の論理的分割

## 検証方法
サブエージェント利用可能性をテスト：
```bash
# document-reviewerが利用可能になることを確認
Task(subagent_type="document-reviewer", ...)
```

🤖 Generated with [Claude Code](https://claude.ai/code)