### PR TITLE
docs: CLAUDE.mdから手動ルール読み込みセクションを削除

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,18 +13,6 @@ AI実行精度最大化のための中核ルール。全ての指示はこのフ
 
 理由：ユーザーの意図と異なる実装を防ぎ、正しい方向性を確保するため
 
-プロジェクト概要と構成については [README.md](./README.md) を参照。
-
-## ルールの読み込み
-
-@docs/rules/project-context.md
-@docs/rules/typescript.md
-@docs/rules/typescript-testing.md
-@docs/rules/technical-spec.md
-@docs/rules/ai-development-guide.md
-@docs/rules/architecture-decision-process.md
-@docs/rules/sub-agents.md
-
 ## 必須実行プロセス
 
 ### 実行フロー（必須手順）


### PR DESCRIPTION
## 概要
CLAUDE.mdから手動でのルール読み込みセクションを削除しました。

## 変更内容
- `## ルールの読み込み` セクションの削除
- `@docs/rules/...` の手動参照記述を削除
- README.md参照リンクの削除

## 変更理由
`/onboard`コマンドでルールが自動読み込みされるようになったため、手動でのルール参照は不要となりました。

## 影響範囲
- [x] ドキュメント

## 変更の種類
- [x] ドキュメント更新
- [ ] 新機能
- [ ] バグ修正
- [ ] 破壊的変更

## 技術的チェックリスト
- [x] コード品質チェック通過 (pnpm check)
- [x] 型チェック通過 (pnpm check-types)
- [x] フォーマット適用 (pnpm fix)

🤖 Generated with [Claude Code](https://claude.ai/code)